### PR TITLE
Fix: Enforce no trailing slashes to resolve GSC canonical/redirect conflicts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,8 +12,8 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
-  site: 'https://davids-place-portfolio.web.app/',
-  trailingSlash: 'ignore',
+  site: 'https://davids-place-portfolio.web.app',
+  trailingSlash: 'never',
   output: 'server',
 
   prefetch: {

--- a/src/components/MainFooter.astro
+++ b/src/components/MainFooter.astro
@@ -59,7 +59,7 @@ const isCookbookAboutPage = Astro.url.pathname.includes('about/cookbook');
 
         <li>
           <a
-            href={`${baseURL}about/`}
+            href={`${baseURL}about`}
             class="hover:text-green-emerald hover:scale-105 block px-2 py-2 text-base tracking-wider transition-[color,scale]"
             >About Me</a
           >
@@ -67,7 +67,7 @@ const isCookbookAboutPage = Astro.url.pathname.includes('about/cookbook');
 
         <li>
           <a
-            href={`${baseURL}blog/`}
+            href={`${baseURL}blog`}
             class="hover:text-green-emerald hover:scale-105 block px-2 py-2 text-base tracking-wider transition-[color,scale]"
             >Blog</a
           >

--- a/src/components/MainNav.astro
+++ b/src/components/MainNav.astro
@@ -14,9 +14,9 @@ const pathname = Astro.url.pathname;
 
 const obj: NavigationLinks = {
   home: `${baseURL}`,
-  cookbook: `${baseURL}about/cookbook/`,
-  about: `${baseURL}about/`,
-  // blog: `${baseURL}blog/`
+  cookbook: `${baseURL}about/cookbook`,
+  about: `${baseURL}about`,
+  // blog: `${baseURL}blog`
 };
 
 let AstroLogo = AstroLogoSpread;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const baseURL = import.meta.env.BASE_URL;
 const isDev = import.meta.env.DEV;
-const urlString: string = new URL(Astro.request.url).href;
+const urlString: string = new URL(Astro.request.url).href.replace(/\/$/, '');
 
 const { title, description, preloadImage, classes = '' } = Astro.props;
 

--- a/src/layouts/Recipe.astro
+++ b/src/layouts/Recipe.astro
@@ -233,7 +233,7 @@ const heroData = [
   <BreadcrumbSchema
     items={[
       { name: 'Home', url: `${siteUrl}${baseURL}` },
-      { name: 'Cookbook', url: `${siteUrl}${baseURL}cookbook/` },
+      { name: 'Cookbook', url: `${siteUrl}${baseURL}cookbook` },
       { name: title, url: currentUrl },
     ]}
   />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -42,7 +42,7 @@ const heroDescription = 'This is not the page you are looking for';
           tags={['Recipes', 'Food', 'Cooking']}
         />
         <Card
-          href={`${baseURL}about/`}
+          href={`${baseURL}about`}
           title="About me"
           body="My gamified personal bio."
           tags={['About', 'Fun', 'Personal']}

--- a/src/pages/about/cookbook.astro
+++ b/src/pages/about/cookbook.astro
@@ -36,7 +36,7 @@ import IconKitchenPackHat from '@images/icons/cookbook/kitchen-pack-hat.svg';
 
 const baseURL = import.meta.env.BASE_URL;
 const siteUrl = Astro.site ? Astro.site.toString().replace(/\/$/, '') : '';
-const currentUrl = `${siteUrl}${baseURL}about/cookbook/`;
+const currentUrl = `${siteUrl}${baseURL}about/cookbook`;
 
 const title = '15+ Vegan & Dairy-Free Recipes | Cookbook';
 const description =

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -22,7 +22,7 @@ const heroDescription = 'Browse my collection of blog posts.';
       {
         allBlogPosts.map((post) => (
           <Card
-            href={`${baseURL}blog/posts/${post.id}/`}
+            href={`${baseURL}blog/posts/${post.id}`}
             title={post.data.title}
             body={post.data.description}
             tags={post.data.tags}

--- a/src/pages/cookbook/index.astro
+++ b/src/pages/cookbook/index.astro
@@ -11,7 +11,7 @@ import RecipeListSchema from '@components/RecipeListSchema.astro';
 
 const baseURL = import.meta.env.BASE_URL;
 const siteUrl = Astro.site ? Astro.site.toString().replace(/\/$/, '') : '';
-const currentUrl = `${siteUrl}${baseURL}cookbook/`;
+const currentUrl = `${siteUrl}${baseURL}cookbook`;
 const allCookbookRecipes = await getCollection('cookbook');
 
 const pageTitle = 'Vegan & Dairy-Free Recipes | Cookbook';
@@ -56,7 +56,7 @@ const backgroundSvgs = [
       {
         allCookbookRecipes.map((recipe) => (
           <Card
-            href={`${baseURL}cookbook/recipes/${recipe.id}/`}
+            href={`${baseURL}cookbook/recipes/${recipe.id}`}
             title={recipe.data.title}
             body={recipe.data.description}
             tags={recipe.data.tags}
@@ -81,7 +81,7 @@ const backgroundSvgs = [
     url={currentUrl}
     items={allCookbookRecipes.map((recipe) => ({
       name: recipe.data.title,
-      url: `${siteUrl}${baseURL}cookbook/recipes/${recipe.id}/`,
+      url: `${siteUrl}${baseURL}cookbook/recipes/${recipe.id}`,
       description: recipe.data.description,
       image: recipe.data.image?.url?.src
         ? `${siteUrl}${recipe.data.image.url.src}`

--- a/src/pages/index-old.astro
+++ b/src/pages/index-old.astro
@@ -66,7 +66,7 @@ const externalLinks = [
 
 const internalLinks = [
   {
-    link: `${baseURL}about/cookbook/`,
+    link: `${baseURL}about/cookbook`,
     title: 'Marketing Page for Cookbook',
     description: 'Learn about my cookbook app through a custom landing page.',
     tags: ['marketing', 'fundamentals', 'informational'],
@@ -78,13 +78,13 @@ const internalLinks = [
     tags: ['recipes', 'food', 'cooking'],
   },
   {
-    link: `${baseURL}about/`,
+    link: `${baseURL}about`,
     title: 'Fun About Page',
     description: 'My gamified personal bio.',
     tags: ['about', 'fun', 'stats'],
   },
   {
-    link: `${baseURL}blog/`,
+    link: `${baseURL}blog`,
     title: 'Blog App',
     description: 'Read articles I’ve written about various topics.',
     tags: ['blog', 'articles', 'writing'],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,7 +70,7 @@ const externalLinks = [
 
 const internalLinks = [
   {
-    link: `${baseURL}about/cookbook/`,
+    link: `${baseURL}about/cookbook`,
     title: 'Marketing Page for Cookbook',
     description: 'Learn about my cookbook app through a custom landing page.',
     tags: ['marketing', 'fundamentals', 'informational'],
@@ -82,13 +82,13 @@ const internalLinks = [
     tags: ['recipes', 'food', 'cooking'],
   },
   {
-    link: `${baseURL}about/`,
+    link: `${baseURL}about`,
     title: 'Fun About Page',
     description: 'My gamified personal bio.',
     tags: ['about', 'fun', 'stats'],
   },
   {
-    link: `${baseURL}blog/`,
+    link: `${baseURL}blog`,
     title: 'Blog App',
     description: 'Read articles I’ve written about various topics.',
     tags: ['blog', 'articles', 'writing'],

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -106,7 +106,8 @@ const selectedImage = imageOptions[randomIndex];
       <Image
         src={selectedImage.image}
         alt={selectedImage.alt}
-        layout="full-width"
+        widths={[400, 800, 1200, 1600]}
+        sizes="(max-width: 768px) 100vw, 40vw"
         loading="eager"
         fetchpriority="high"
         class="absolute top-0 left-0 w-full h-full object-cover"

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -106,8 +106,7 @@ const selectedImage = imageOptions[randomIndex];
       <Image
         src={selectedImage.image}
         alt={selectedImage.alt}
-        widths={[400, 800, 1200, 1600]}
-        sizes="(max-width: 768px) 100vw, 40vw"
+        layout="full-width"
         loading="eager"
         fetchpriority="high"
         class="absolute top-0 left-0 w-full h-full object-cover"

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -2,7 +2,7 @@
 import { app } from '../firebase/server';
 import { getAuth } from 'firebase-admin/auth';
 import Base from '@layouts/Base.astro';
-import { Image, getImage } from 'astro:assets';
+import { Image } from 'astro:assets';
 
 import imageFlowerFrame from '@images/general/background-flower-frame.jpg';
 import imageLaptop from '@images/general/background-laptop.jpg';
@@ -72,28 +72,12 @@ const imageOptions = [
 
 const randomIndex = Math.floor(Math.random() * imageOptions.length);
 const selectedImage = imageOptions[randomIndex];
-
-// Pre-process the selected image for preloading
-// Use 1200px as base - covers tablet landscape (768px * 0.4 * 2 = ~614px for 2x displays)
-const processedImage = await getImage({
-  src: selectedImage.image,
-  width: 1200,
-  format: 'webp',
-});
-
-// Preload the randomly selected image for optimal LCP
-const preloadImageData = {
-  src: processedImage.src,
-  format: 'webp',
-  pathname: Astro.url.pathname,
-};
 ---
 
 <Base
   title="Sign in to Your Account to View Your Content and Contributions"
   description="Sign in to your account at David’s Place to access your content and features. Manage your recipes, blog posts, and discussions all in one place."
   classes="flex flex-col justify-between"
-  preloadImage={preloadImageData}
 >
   <div class="grid grid-cols-1 tablet:grid-cols-5 grow">
     <header
@@ -122,13 +106,10 @@ const preloadImageData = {
       <Image
         src={selectedImage.image}
         alt={selectedImage.alt}
-        width={selectedImage.image.width}
-        height={selectedImage.image.height}
-        widths={[400, 600, 800, 1200, 1600]}
-        sizes="(max-width: 767px) 100vw, 40vw"
+        widths={[400, 800, 1200, 1600]}
+        sizes="(max-width: 768px) 100vw, 40vw"
         loading="eager"
         fetchpriority="high"
-        decoding="async"
         class="absolute top-0 left-0 w-full h-full object-cover"
       />
     </header>

--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -2,7 +2,7 @@
 import { app } from '../firebase/server';
 import { getAuth } from 'firebase-admin/auth';
 import Base from '@layouts/Base.astro';
-import { Image } from 'astro:assets';
+import { Image, getImage } from 'astro:assets';
 
 import imageFlowerFrame from '@images/general/background-flower-frame.jpg';
 import imageLaptop from '@images/general/background-laptop.jpg';
@@ -72,12 +72,28 @@ const imageOptions = [
 
 const randomIndex = Math.floor(Math.random() * imageOptions.length);
 const selectedImage = imageOptions[randomIndex];
+
+// Pre-process the selected image for preloading
+// Use 1200px as base - covers tablet landscape (768px * 0.4 * 2 = ~614px for 2x displays)
+const processedImage = await getImage({
+  src: selectedImage.image,
+  width: 1200,
+  format: 'webp',
+});
+
+// Preload the randomly selected image for optimal LCP
+const preloadImageData = {
+  src: processedImage.src,
+  format: 'webp',
+  pathname: Astro.url.pathname,
+};
 ---
 
 <Base
   title="Sign in to Your Account to View Your Content and Contributions"
   description="Sign in to your account at David’s Place to access your content and features. Manage your recipes, blog posts, and discussions all in one place."
   classes="flex flex-col justify-between"
+  preloadImage={preloadImageData}
 >
   <div class="grid grid-cols-1 tablet:grid-cols-5 grow">
     <header
@@ -106,10 +122,13 @@ const selectedImage = imageOptions[randomIndex];
       <Image
         src={selectedImage.image}
         alt={selectedImage.alt}
-        widths={[400, 800, 1200, 1600]}
-        sizes="(max-width: 768px) 100vw, 40vw"
+        width={selectedImage.image.width}
+        height={selectedImage.image.height}
+        widths={[400, 600, 800, 1200, 1600]}
+        sizes="(max-width: 767px) 100vw, 40vw"
         loading="eager"
         fetchpriority="high"
+        decoding="async"
         class="absolute top-0 left-0 w-full h-full object-cover"
       />
     </header>


### PR DESCRIPTION
## Problem

Google Search Console was finding duplicate pages with and without trailing slashes (e.g., `/cookbook/` and `/cookbook`), flagging issues like:
- "Alternate page with proper canonical tag"
- "Page with redirect"

The root cause: redirects pointed to URLs without trailing slashes, but canonical tags included them—creating a conflict for Google's indexer.

## Solution

**Astro Config:**
- Set `trailingSlash: 'never'` to enforce no trailing slashes site-wide
- Removed trailing slash from `site` URL

**Internal Links:**
- Updated all internal links to exclude trailing slashes
- Fixed breadcrumb schema URLs for consistency

**Files Changed (10):**
- `astro.config.mjs`
- `src/components/MainNav.astro`, `MainFooter.astro`
- `src/layouts/Recipe.astro`
- `src/pages/index.astro`, `index-old.astro`, `404.astro`
- `src/pages/about/cookbook.astro`
- `src/pages/blog/index.astro`
- `src/pages/cookbook/index.astro`

## Impact

- Eliminates duplicate page indexing in GSC
- Consistent URL structure across site
- Improved SEO clarity for search engines

## Testing

✅ Build passes with no errors
✅ All internal navigation uses consistent URL format

## Post-Merge

1. Request re-indexing in GSC for key pages
2. Monitor GSC for 1-2 weeks to confirm duplicate page warnings disappear